### PR TITLE
Add support for etcd client version 3

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	
+
 	etcd "github.com/coreos/etcd/client"
 )
 

--- a/clientv3.go
+++ b/clientv3.go
@@ -9,7 +9,6 @@ import (
 	"time"
 )
 
-
 type clientv3 struct {
 	client  *etcdv3.Client
 	ctx     context.Context
@@ -71,7 +70,7 @@ func (c *clientv3) GetEntries(key string) ([]string, error) {
 	if c.client == nil {
 		return nil, ErrNilClient
 	}
-	
+
 	// set the timeout for this requisition
 	timeoutCtx, cancel := context.WithTimeout(c.ctx, c.timeout)
 	resp, err := c.client.Get(timeoutCtx, key, etcdv3.WithPrefix())
@@ -97,7 +96,7 @@ func (c *clientv3) GetEntries(key string) ([]string, error) {
 
 // WatchPrefix implements the etcd Client interface.
 func (c *clientv3) WatchPrefix(prefix string, ch chan struct{}) {
-	
+
 	if c.client == nil {
 		return
 	}

--- a/clientv3.go
+++ b/clientv3.go
@@ -102,7 +102,6 @@ func (c *clientv3) WatchPrefix(prefix string, ch chan struct{}) {
 		return
 	}
 	watch := c.client.Watch(c.ctx, prefix, etcdv3.WithPrefix())
-	// watch := c.keysAPI.Watcher(prefix, &etcd.WatcherOptions{AfterIndex: 0, Recursive: true})
 	ch <- struct{}{} // make sure caller invokes GetEntries
 	for _ := range watch {
 		ch <- struct{}{}

--- a/clientv3.go
+++ b/clientv3.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	etcdv3 "github.com/coreos/etcd/clientv3"
 	"io/ioutil"
 	"time"
+
+	etcdv3 "github.com/coreos/etcd/clientv3"
 )
 
 type clientv3 struct {
@@ -103,14 +104,7 @@ func (c *clientv3) WatchPrefix(prefix string, ch chan struct{}) {
 	watch := c.client.Watch(c.ctx, prefix, etcdv3.WithPrefix())
 	// watch := c.keysAPI.Watcher(prefix, &etcd.WatcherOptions{AfterIndex: 0, Recursive: true})
 	ch <- struct{}{} // make sure caller invokes GetEntries
-	for {
-		select {
-		case _, ok := <-watch:
-			if ok {
-				ch <- struct{}{}
-			} else {
-				// Do nothing
-			}
-		}
+	for _ := range watch {
+		ch <- struct{}{}
 	}
 }

--- a/clientv3_test.go
+++ b/clientv3_test.go
@@ -1,0 +1,86 @@
+package etcd
+
+import (
+	"context"
+	`testing`
+	`time`
+)
+
+func TestNewClient_withDefaultsV3(t *testing.T) {
+	client, err := NewClientV3(
+		context.Background(),
+		[]string{"http://irrelevant:12345"},
+		ClientOptions{},
+	)
+	if err == nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	if client != nil {
+		t.Fatal("expected new Client, got nil")
+	}
+}
+
+// NewClient should fail when providing invalid or missing endpoints.
+func TestOptionsV3(t *testing.T) {
+	a, err := NewClientV3(
+		context.Background(),
+		[]string{},
+		ClientOptions{
+			Cert:                    "",
+			Key:                     "",
+			CACert:                  "",
+			DialTimeout:             2 * time.Second,
+			DialKeepAlive:           2 * time.Second,
+			HeaderTimeoutPerRequest: 2 * time.Second,
+		},
+	)
+	if err == nil {
+		t.Errorf("expected error: %v", err)
+	}
+	if a != nil {
+		t.Fatalf("expected client to be nil on failure")
+	}
+	
+	_, err = NewClientV3(
+		context.Background(),
+		[]string{"http://irrelevant:12345"},
+		ClientOptions{
+			Cert:                    "blank.crt",
+			Key:                     "blank.key",
+			CACert:                  "blank.CACert",
+			DialTimeout:             2 * time.Second,
+			DialKeepAlive:           2 * time.Second,
+			HeaderTimeoutPerRequest: 2 * time.Second,
+		},
+	)
+	if err == nil {
+		t.Errorf("expected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+func newFakeClientV3(ctx context.Context) Client {
+	return &clientv3 {
+		client:			nil,
+		ctx:				ctx,
+		timeout:    3 * time.Second,
+	}
+}
+
+func TestWatchPrefixV3(t *testing.T) {
+	
+	cv3 := newFakeClientV3(context.Background())
+	
+	ch  := make(chan struct{})
+	cv3.WatchPrefix("prefix", ch)
+}
+
+func TestGetEntriesV3(t *testing.T) {
+	cv3 := newFakeClientV3(context.Background())
+	
+	res, err := cv3.GetEntries("prefix")
+	if res != nil || err == nil {
+		t.Errorf("expected client error")
+	}
+}

--- a/clientv3_test.go
+++ b/clientv3_test.go
@@ -2,8 +2,8 @@ package etcd
 
 import (
 	"context"
-	`testing`
-	`time`
+	"testing"
+	"time"
 )
 
 func TestNewClient_withDefaultsV3(t *testing.T) {
@@ -40,7 +40,7 @@ func TestOptionsV3(t *testing.T) {
 	if a != nil {
 		t.Fatalf("expected client to be nil on failure")
 	}
-	
+
 	_, err = NewClientV3(
 		context.Background(),
 		[]string{"http://irrelevant:12345"},
@@ -61,24 +61,24 @@ func TestOptionsV3(t *testing.T) {
 // ---------------------------------------------------------------------------------------------------------------------
 
 func newFakeClientV3(ctx context.Context) Client {
-	return &clientv3 {
-		client:			nil,
-		ctx:				ctx,
-		timeout:    3 * time.Second,
+	return &clientv3{
+		client:  nil,
+		ctx:     ctx,
+		timeout: 3 * time.Second,
 	}
 }
 
 func TestWatchPrefixV3(t *testing.T) {
-	
+
 	cv3 := newFakeClientV3(context.Background())
-	
-	ch  := make(chan struct{})
+
+	ch := make(chan struct{})
 	cv3.WatchPrefix("prefix", ch)
 }
 
 func TestGetEntriesV3(t *testing.T) {
 	cv3 := newFakeClientV3(context.Background())
-	
+
 	res, err := cv3.GetEntries("prefix")
 	if res != nil || err == nil {
 		t.Errorf("expected client error")

--- a/config.go
+++ b/config.go
@@ -85,8 +85,8 @@ func parseVersion(cfg map[string]interface{}) (string, error) {
 	if !ok {
 		return "v2", nil
 	}
-	result := value.(string)
-	if result != "v2" && result != "v3" {
+	result, ok := value.(string)
+	if !ok || (result != "v2" && result != "v3") {
 		result = "v2"
 	}
 	return result, nil

--- a/config.go
+++ b/config.go
@@ -52,6 +52,8 @@ var (
 	ErrBadConfig = fmt.Errorf("unable to create the etcd client with the received config")
 	// ErrNoMachines is the error to be returned when the config has not defined one or more servers
 	ErrNoMachines = fmt.Errorf("unable to create the etcd client without a set of servers")
+	// ErrNilClient is the error to be nil client
+	ErrNilClient = fmt.Errorf("nil etcd client")
 )
 
 // New creates an etcd client with the config extracted from the extra config param
@@ -86,7 +88,7 @@ func parseVersion(cfg map[string]interface{}) (string, error) {
 		return "v2", nil
 	}
 	result := value.(string)
-	if result != "v2" || result != "v3" {
+	if result != "v2" && result != "v3" {
 		result = "v2"
 		log.Warnf("")
 	}

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/common/log"
 	"time"
 
 	"github.com/devopsfaith/krakend/config"
@@ -75,11 +74,10 @@ func New(ctx context.Context, e config.ExtraConfig) (Client, error) {
 		return nil, err
 	}
 
-	if version == "v2" {
-		return NewClient(ctx, machines, parseOptions(tmp))
-	} else {
+	if version == "v3" {
 		return NewClientV3(ctx, machines, parseOptions(tmp))
 	}
+	return NewClient(ctx, machines, parseOptions(tmp))
 }
 
 func parseVersion(cfg map[string]interface{}) (string, error) {
@@ -90,7 +88,6 @@ func parseVersion(cfg map[string]interface{}) (string, error) {
 	result := value.(string)
 	if result != "v2" && result != "v3" {
 		result = "v2"
-		log.Warnf("")
 	}
 	return result, nil
 }

--- a/example/krakend.json
+++ b/example/krakend.json
@@ -12,7 +12,7 @@
             "backend": [
                 {
                     "host": [
-                        "github.com"
+                        "github"
                     ],
                     "url_pattern": "/",
                     "disable_host_sanitize": true,

--- a/example/krakend.json
+++ b/example/krakend.json
@@ -7,12 +7,15 @@
     "endpoints": [
         {
             "endpoint": "/github/{user}",
+			"method": "GET",
+			"output_encoding": "no-op",
             "backend": [
                 {
                     "host": [
-                        "github"
+                        "github.com"
                     ],
                     "url_pattern": "/",
+                    "disable_host_sanitize": true,
                     "whitelist": [
                         "authorizations_url",
                         "code_search_url"
@@ -20,7 +23,29 @@
                     "sd": "etcd"
                 }
             ]
-        },
+        },    
+		{
+		  "endpoint": "/",
+		  "method": "GET",
+		  "extra_config": {},
+		  "output_encoding": "no-op",
+		  "concurrent_calls": 1,
+		  "querystring_params":[
+			"*"
+		  ],
+		  "backend": [
+			{
+			  "url_pattern": "/",
+			  "encoding": "no-op",
+			  "extra_config": {},
+			  "sd": "etcd",
+			  "host": [
+				"github.com"
+			  ],
+			  "disable_host_sanitize": true
+			}
+		  ]
+		},
         {
             "endpoint": "/combination/{id}",
             "backend": [
@@ -29,6 +54,7 @@
                         "jsonplaceholder.typicode"
                     ],
                     "url_pattern": "/posts?userId={id}",
+					"encoding": "no-op",
                     "is_collection": true,
                     "mapping": {
                         "collection": "posts"
@@ -53,6 +79,7 @@
     "extra_config": {
         "github_com/devopsfaith/krakend-etcd": {
             "machines": [ "http://192.168.110.111:2379" ],
+			"client_version": "v3",
             "options": {
                 "dial_timeout": "5s",
                 "dial_keepalive": "30s",

--- a/example/krakend.json
+++ b/example/krakend.json
@@ -17,8 +17,7 @@
                         "authorizations_url",
                         "code_search_url"
                     ],
-                    "sd": "etcd",
-                    
+                    "sd": "etcd"
                 }
             ]
         },
@@ -53,7 +52,7 @@
     ],
     "extra_config": {
         "github_com/devopsfaith/krakend-etcd": {
-            "machines": [ "http://192.168.99.100:4001" ],
+            "machines": [ "http://192.168.110.111:2379" ],
             "options": {
                 "dial_timeout": "5s",
                 "dial_keepalive": "30s",

--- a/example/main.go
+++ b/example/main.go
@@ -20,7 +20,7 @@ func main() {
 	port := flag.Int("p", 0, "Port of the service")
 	logLevel := flag.String("l", "ERROR", "Logging level")
 	debug := flag.Bool("d", false, "Enable the debug")
-	configFile := flag.String("c", "E:/megvii/project/go_learning/krakend-etcd/example/krakend.json", "Path to the configuration filename")
+	configFile := flag.String("c", "/etc/krakend/configuration.json", "Path to the configuration filename")
 	flag.Parse()
 
 	parser := config.NewParser()

--- a/example/main.go
+++ b/example/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"flag"
+	`github.com/devopsfaith/krakend/router`
 	"log"
 	"os"
-
+	
 	"github.com/gin-gonic/gin"
-
+	
 	"github.com/devopsfaith/krakend-etcd"
-	"github.com/devopsfaith/krakend-viper"
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
@@ -20,10 +20,10 @@ func main() {
 	port := flag.Int("p", 0, "Port of the service")
 	logLevel := flag.String("l", "ERROR", "Logging level")
 	debug := flag.Bool("d", false, "Enable the debug")
-	configFile := flag.String("c", "/etc/krakend/configuration.json", "Path to the configuration filename")
+	configFile := flag.String("c", "E:/megvii/project/go_learning/krakend-etcd/example/krakend.json", "Path to the configuration filename")
 	flag.Parse()
-
-	parser := viper.New()
+	
+	parser 			:= config.NewParser()
 	serviceConfig, err := parser.Parse(*configFile)
 	if err != nil {
 		log.Fatal("ERROR:", err.Error())
@@ -54,6 +54,7 @@ func main() {
 			logger,
 			proxy.DefaultFactoryWithSubscriber(logger, etcd.SubscriberFactory(ctx, etcdClient)),
 		},
+		RunServer:      router.RunServer,
 	})
 
 	routerFactory.NewWithContext(ctx).Run(serviceConfig)

--- a/example/main.go
+++ b/example/main.go
@@ -3,17 +3,16 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/devopsfaith/krakend/router"
-	"github.com/khvysofq/krakend-etcd"
 	"log"
 	"os"
 
-	"github.com/gin-gonic/gin"
-
+	"github.com/devopsfaith/krakend-etcd"
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 	krakendgin "github.com/devopsfaith/krakend/router/gin"
+	"github.com/gin-gonic/gin"
 )
 
 func main() {

--- a/example/main.go
+++ b/example/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"flag"
-	`github.com/devopsfaith/krakend/router`
+	"github.com/devopsfaith/krakend/router"
 	"github.com/khvysofq/krakend-etcd"
 	"log"
 	"os"
-	
+
 	"github.com/gin-gonic/gin"
-	
+
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
@@ -22,8 +22,8 @@ func main() {
 	debug := flag.Bool("d", false, "Enable the debug")
 	configFile := flag.String("c", "E:/megvii/project/go_learning/krakend-etcd/example/krakend.json", "Path to the configuration filename")
 	flag.Parse()
-	
-	parser 			:= config.NewParser()
+
+	parser := config.NewParser()
 	serviceConfig, err := parser.Parse(*configFile)
 	if err != nil {
 		log.Fatal("ERROR:", err.Error())
@@ -54,7 +54,7 @@ func main() {
 			logger,
 			proxy.DefaultFactoryWithSubscriber(logger, etcd.SubscriberFactory(ctx, etcdClient)),
 		},
-		RunServer:      router.RunServer,
+		RunServer: router.RunServer,
 	})
 
 	routerFactory.NewWithContext(ctx).Run(serviceConfig)

--- a/example/main.go
+++ b/example/main.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"flag"
 	`github.com/devopsfaith/krakend/router`
+	"github.com/khvysofq/krakend-etcd"
 	"log"
 	"os"
 	
 	"github.com/gin-gonic/gin"
 	
-	"github.com/devopsfaith/krakend-etcd"
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"

--- a/subscriber.go
+++ b/subscriber.go
@@ -3,7 +3,7 @@ package etcd
 import (
 	"context"
 	"sync"
-
+	
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/sd"
 )

--- a/subscriber.go
+++ b/subscriber.go
@@ -3,7 +3,7 @@ package etcd
 import (
 	"context"
 	"sync"
-	
+
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/sd"
 )


### PR DESCRIPTION
Hi, kpacha. This PR is primarily to support the functionality of the ETCD clientv3. The major changes are as follows

- Add `clientv3.go`、`clientv3_testing.go` in the root of the source code.
- Move some common parts into the `config.go`

Both modes are supported through profile configuration, just add `"client_version": "v3"` option in `extra_config`

```json
"extra_config": {
    "github_com/devopsfaith/krakend-etcd": {
        "machines": [ "http://192.168.110.111:2379" ],
		"client_version": "v3",
        "options": {
            "dial_timeout": "5s",
            "dial_keepalive": "30s",
            "header_timeout": "1s"
        }
    }
}
```

- `"client_version": "v3"` using the etcd clientv3
- `"client_version": "v2"` using the etcd clientv2 (old version)

The default value is `v2`, if you are not set `"client_version"`. I have tested in my local machines.

---

Among other things, there is one small problem. I used go mod to manage my go packages. but in the original code of the `example/main.go`, the `github.com/devopsfaith/krakend-etcd`(v 3.3.10 or newer version) and `github.com/devopsfaith/krakend-viper` conflict when load package `github.com/ugorji/go`

- `github.com/devopsfaith/krakend-etcd`(v 3.3.12) need `github.com/ugorji/go@v1.1.1`
- `github.com/devopsfaith/krakend-viper` auto need `github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8`

They need the same package, but not the same directory and not the same version. The go mod can't handle this situation. see [https://github.com/spf13/viper/issues/658](https://github.com/spf13/viper/issues/658)

So, in the `example/main.go`, I can only change `github.com/devopsfaith/krakend-viper` to `github.com/devopsfaith/krakend/config`